### PR TITLE
Implement Alignment for Align<2^29>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //! ```
 #![no_std]
 use core::{
-    cmp::{PartialOrd, Ordering},
+    cmp::{Ordering, PartialOrd},
     fmt::{self, Debug},
     hash::{Hash, Hasher},
 };
@@ -102,10 +102,9 @@ pub struct Align<const N: usize>([<Self as private::Sealed>::Archetype; 0])
 where
     Self: Alignment;
 
-
 impl<const N: usize> Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     /// An instance of `Align<N>`.
     /// ```
@@ -156,67 +155,67 @@ mod private {
         type Archetype: Copy + Eq + PartialEq + Send + Sync + Unpin;
     }
 
-    impl Sealed for super::Align<        1> { type Archetype = Align1;         }
-    impl Sealed for super::Align<        2> { type Archetype = Align2;         }
-    impl Sealed for super::Align<        4> { type Archetype = Align4;         }
-    impl Sealed for super::Align<        8> { type Archetype = Align8;         }
-    impl Sealed for super::Align<       16> { type Archetype = Align16;        }
-    impl Sealed for super::Align<       32> { type Archetype = Align32;        }
-    impl Sealed for super::Align<       64> { type Archetype = Align64;        }
-    impl Sealed for super::Align<      128> { type Archetype = Align128;       }
-    impl Sealed for super::Align<      256> { type Archetype = Align256;       }
-    impl Sealed for super::Align<      512> { type Archetype = Align512;       }
-    impl Sealed for super::Align<     1024> { type Archetype = Align1024;      }
-    impl Sealed for super::Align<     2048> { type Archetype = Align2048;      }
-    impl Sealed for super::Align<     4096> { type Archetype = Align4096;      }
-    impl Sealed for super::Align<     8192> { type Archetype = Align8192;      }
-    impl Sealed for super::Align<    16384> { type Archetype = Align16384;     }
-    impl Sealed for super::Align<    32768> { type Archetype = Align32768;     }
-    impl Sealed for super::Align<    65536> { type Archetype = Align65536;     }
-    impl Sealed for super::Align<   131072> { type Archetype = Align131072;    }
-    impl Sealed for super::Align<   262144> { type Archetype = Align262144;    }
-    impl Sealed for super::Align<   524288> { type Archetype = Align524288;    }
-    impl Sealed for super::Align<  1048576> { type Archetype = Align1048576;   }
-    impl Sealed for super::Align<  2097152> { type Archetype = Align2097152;   }
-    impl Sealed for super::Align<  4194304> { type Archetype = Align4194304;   }
-    impl Sealed for super::Align<  8388608> { type Archetype = Align8388608;   }
-    impl Sealed for super::Align< 16777216> { type Archetype = Align16777216;  }
-    impl Sealed for super::Align< 33554432> { type Archetype = Align33554432;  }
-    impl Sealed for super::Align< 67108864> { type Archetype = Align67108864;  }
-    impl Sealed for super::Align<134217728> { type Archetype = Align134217728; }
-    impl Sealed for super::Align<268435456> { type Archetype = Align268435456; }
+    #[rustfmt::skip] impl Sealed for super::Align<        1> { type Archetype = Align1;         }
+    #[rustfmt::skip] impl Sealed for super::Align<        2> { type Archetype = Align2;         }
+    #[rustfmt::skip] impl Sealed for super::Align<        4> { type Archetype = Align4;         }
+    #[rustfmt::skip] impl Sealed for super::Align<        8> { type Archetype = Align8;         }
+    #[rustfmt::skip] impl Sealed for super::Align<       16> { type Archetype = Align16;        }
+    #[rustfmt::skip] impl Sealed for super::Align<       32> { type Archetype = Align32;        }
+    #[rustfmt::skip] impl Sealed for super::Align<       64> { type Archetype = Align64;        }
+    #[rustfmt::skip] impl Sealed for super::Align<      128> { type Archetype = Align128;       }
+    #[rustfmt::skip] impl Sealed for super::Align<      256> { type Archetype = Align256;       }
+    #[rustfmt::skip] impl Sealed for super::Align<      512> { type Archetype = Align512;       }
+    #[rustfmt::skip] impl Sealed for super::Align<     1024> { type Archetype = Align1024;      }
+    #[rustfmt::skip] impl Sealed for super::Align<     2048> { type Archetype = Align2048;      }
+    #[rustfmt::skip] impl Sealed for super::Align<     4096> { type Archetype = Align4096;      }
+    #[rustfmt::skip] impl Sealed for super::Align<     8192> { type Archetype = Align8192;      }
+    #[rustfmt::skip] impl Sealed for super::Align<    16384> { type Archetype = Align16384;     }
+    #[rustfmt::skip] impl Sealed for super::Align<    32768> { type Archetype = Align32768;     }
+    #[rustfmt::skip] impl Sealed for super::Align<    65536> { type Archetype = Align65536;     }
+    #[rustfmt::skip] impl Sealed for super::Align<   131072> { type Archetype = Align131072;    }
+    #[rustfmt::skip] impl Sealed for super::Align<   262144> { type Archetype = Align262144;    }
+    #[rustfmt::skip] impl Sealed for super::Align<   524288> { type Archetype = Align524288;    }
+    #[rustfmt::skip] impl Sealed for super::Align<  1048576> { type Archetype = Align1048576;   }
+    #[rustfmt::skip] impl Sealed for super::Align<  2097152> { type Archetype = Align2097152;   }
+    #[rustfmt::skip] impl Sealed for super::Align<  4194304> { type Archetype = Align4194304;   }
+    #[rustfmt::skip] impl Sealed for super::Align<  8388608> { type Archetype = Align8388608;   }
+    #[rustfmt::skip] impl Sealed for super::Align< 16777216> { type Archetype = Align16777216;  }
+    #[rustfmt::skip] impl Sealed for super::Align< 33554432> { type Archetype = Align33554432;  }
+    #[rustfmt::skip] impl Sealed for super::Align< 67108864> { type Archetype = Align67108864;  }
+    #[rustfmt::skip] impl Sealed for super::Align<134217728> { type Archetype = Align134217728; }
+    #[rustfmt::skip] impl Sealed for super::Align<268435456> { type Archetype = Align268435456; }
 
     // NB: It'd be great if these could be void enums, as doing so
     // greatly simplifies the expansion of derived traits.
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        1))] pub struct Align1         {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        2))] pub struct Align2         {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        4))] pub struct Align4         {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        8))] pub struct Align8         {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       16))] pub struct Align16        {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       32))] pub struct Align32        {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       64))] pub struct Align64        {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      128))] pub struct Align128       {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      256))] pub struct Align256       {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      512))] pub struct Align512       {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     1024))] pub struct Align1024      {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     2048))] pub struct Align2048      {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     4096))] pub struct Align4096      {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     8192))] pub struct Align8192      {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    16384))] pub struct Align16384     {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    32768))] pub struct Align32768     {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    65536))] pub struct Align65536     {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   131072))] pub struct Align131072    {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   262144))] pub struct Align262144    {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   524288))] pub struct Align524288    {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  1048576))] pub struct Align1048576   {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  2097152))] pub struct Align2097152   {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  4194304))] pub struct Align4194304   {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  8388608))] pub struct Align8388608   {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 16777216))] pub struct Align16777216  {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 33554432))] pub struct Align33554432  {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 67108864))] pub struct Align67108864  {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(134217728))] pub struct Align134217728 {}
-    #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(268435456))] pub struct Align268435456 {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        1))] pub struct Align1         {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        2))] pub struct Align2         {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        4))] pub struct Align4         {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(        8))] pub struct Align8         {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       16))] pub struct Align16        {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       32))] pub struct Align32        {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(       64))] pub struct Align64        {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      128))] pub struct Align128       {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      256))] pub struct Align256       {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(      512))] pub struct Align512       {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     1024))] pub struct Align1024      {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     2048))] pub struct Align2048      {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     4096))] pub struct Align4096      {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(     8192))] pub struct Align8192      {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    16384))] pub struct Align16384     {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    32768))] pub struct Align32768     {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(    65536))] pub struct Align65536     {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   131072))] pub struct Align131072    {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   262144))] pub struct Align262144    {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(   524288))] pub struct Align524288    {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  1048576))] pub struct Align1048576   {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  2097152))] pub struct Align2097152   {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  4194304))] pub struct Align4194304   {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(  8388608))] pub struct Align8388608   {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 16777216))] pub struct Align16777216  {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 33554432))] pub struct Align33554432  {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 67108864))] pub struct Align67108864  {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(134217728))] pub struct Align134217728 {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(268435456))] pub struct Align268435456 {}
 }
 
 // NB: While these impls could be reduced to a single:
@@ -225,48 +224,44 @@ mod private {
 //        Self: private::Sealed
 //    {}
 // …leaving them enumerated makes explicit what alignments are valid.
-unsafe impl Alignment for Align<        1> {}
-unsafe impl Alignment for Align<        2> {}
-unsafe impl Alignment for Align<        4> {}
-unsafe impl Alignment for Align<        8> {}
-unsafe impl Alignment for Align<       16> {}
-unsafe impl Alignment for Align<       32> {}
-unsafe impl Alignment for Align<       64> {}
-unsafe impl Alignment for Align<      128> {}
-unsafe impl Alignment for Align<      256> {}
-unsafe impl Alignment for Align<      512> {}
-unsafe impl Alignment for Align<     1024> {}
-unsafe impl Alignment for Align<     2048> {}
-unsafe impl Alignment for Align<     4096> {}
-unsafe impl Alignment for Align<     8192> {}
-unsafe impl Alignment for Align<    16384> {}
-unsafe impl Alignment for Align<    32768> {}
-unsafe impl Alignment for Align<    65536> {}
-unsafe impl Alignment for Align<   131072> {}
-unsafe impl Alignment for Align<   262144> {}
-unsafe impl Alignment for Align<   524288> {}
-unsafe impl Alignment for Align<  1048576> {}
-unsafe impl Alignment for Align<  2097152> {}
-unsafe impl Alignment for Align<  4194304> {}
-unsafe impl Alignment for Align<  8388608> {}
-unsafe impl Alignment for Align< 16777216> {}
-unsafe impl Alignment for Align< 33554432> {}
-unsafe impl Alignment for Align< 67108864> {}
-unsafe impl Alignment for Align<134217728> {}
-unsafe impl Alignment for Align<268435456> {}
-
+#[rustfmt::skip] unsafe impl Alignment for Align<        1> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<        2> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<        4> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<        8> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<       16> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<       32> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<       64> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<      128> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<      256> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<      512> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<     1024> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<     2048> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<     4096> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<     8192> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<    16384> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<    32768> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<    65536> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<   131072> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<   262144> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<   524288> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<  1048576> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<  2097152> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<  4194304> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<  8388608> {}
+#[rustfmt::skip] unsafe impl Alignment for Align< 16777216> {}
+#[rustfmt::skip] unsafe impl Alignment for Align< 33554432> {}
+#[rustfmt::skip] unsafe impl Alignment for Align< 67108864> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<134217728> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<268435456> {}
 
 // NB: These traits are implemented explicitly, rather than derived,
 // because their implementations do not depend on `Align`'s field.
 
-impl<const N: usize> Copy for Align<N>
-where
-    Self: Alignment
-{}
+impl<const N: usize> Copy for Align<N> where Self: Alignment {}
 
 impl<const N: usize> Clone for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline(always)]
     fn clone(&self) -> Self {
@@ -276,7 +271,7 @@ where
 
 impl<const N: usize> Debug for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -286,7 +281,7 @@ where
 
 impl<const N: usize> Default for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline(always)]
     fn default() -> Self {
@@ -296,7 +291,7 @@ where
 
 impl<const N: usize> Hash for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline(always)]
     fn hash<H: Hasher>(&self, _: &mut H) {}
@@ -304,7 +299,7 @@ where
 
 impl<const N: usize> Ord for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline(always)]
     fn cmp(&self, _: &Self) -> Ordering {
@@ -314,7 +309,7 @@ where
 
 impl<const N: usize> PartialOrd<Self> for Align<N>
 where
-    Self: Alignment
+    Self: Alignment,
 {
     #[inline(always)]
     fn partial_cmp(&self, _: &Self) -> Option<Ordering> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! assert_eq!(align_of_val(&foo), 8);
 //! ```
 //!
-//! Valid alignments are powers of two less-than-or-equal to 2<sup>28</sup>.
+//! Valid alignments are powers of two less-than-or-equal to 2<sup>29</sup>.
 //! Supplying an *invalid* alignment to [`Align`] is a type error:
 //! ```compile_fail
 //! use elain::Align;
@@ -184,6 +184,7 @@ mod private {
     #[rustfmt::skip] impl Sealed for super::Align< 67108864> { type Archetype = Align67108864;  }
     #[rustfmt::skip] impl Sealed for super::Align<134217728> { type Archetype = Align134217728; }
     #[rustfmt::skip] impl Sealed for super::Align<268435456> { type Archetype = Align268435456; }
+    #[rustfmt::skip] impl Sealed for super::Align<536870912> { type Archetype = Align536870912; }
 
     // NB: It'd be great if these could be void enums, as doing so
     // greatly simplifies the expansion of derived traits.
@@ -216,6 +217,7 @@ mod private {
     #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align( 67108864))] pub struct Align67108864  {}
     #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(134217728))] pub struct Align134217728 {}
     #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(268435456))] pub struct Align268435456 {}
+    #[rustfmt::skip] #[derive(Copy, Clone, Eq, PartialEq)] #[repr(align(536870912))] pub struct Align536870912 {}
 }
 
 // NB: While these impls could be reduced to a single:
@@ -253,6 +255,7 @@ mod private {
 #[rustfmt::skip] unsafe impl Alignment for Align< 67108864> {}
 #[rustfmt::skip] unsafe impl Alignment for Align<134217728> {}
 #[rustfmt::skip] unsafe impl Alignment for Align<268435456> {}
+#[rustfmt::skip] unsafe impl Alignment for Align<536870912> {}
 
 // NB: These traits are implemented explicitly, rather than derived,
 // because their implementations do not depend on `Align`'s field.


### PR DESCRIPTION
Hi. Firstly I would like to thank you for this very nice crate! Secondly I hope you don't mind that I created PR without opening an issue first. I though that change is so simple, that it wouldn't make much sense.

In this PR I implement `Alignment` for `Align<2^29>`. [The Rust Reference](https://doc.rust-lang.org/reference/type-layout.html#the-alignment-modifiers) states that:

> The alignment is specified as an integer parameter in the form of `#[repr(align(x))]` or `#[repr(packed(x))]`. The alignment value must be a power of two from 1 up to 2<sup>29</sup>. For packed, if no value is given, as in `#[repr(packed)]`, then the value is 1.

elain however allows alignment only up to 2^28.

I don't know what MSRV of this crate is, but from what I have noticed from a quick binary search of rust compilers on godbolt, alignment of 2^29 was possible since `#[repr(align(x))]` was stabilized. So this shouldn't be breaking change.